### PR TITLE
Make copy_carts consistently create .p8.png files

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -37,9 +37,9 @@ copy_carts() {
 
         if [ -f "$HOME/bbs/carts/temp-$FILENAME.nfo" ]; then
             TITLE="$(grep title: "$HOME/bbs/carts/temp-$FILENAME.nfo" | cut -d: -f2-)"
-            cp -f "$cart" "$ROM_FOLDER/$TITLE.p8"
+            cp -f "$cart" "$ROM_FOLDER/$TITLE.p8.png"
         else
-            cp -f "$cart" "$ROM_FOLDER/$FILENAME.p8"
+            cp -f "$cart" "$ROM_FOLDER/$FILENAME"
         fi
     done
     sync


### PR DESCRIPTION
I noticed that the carts that end up in the roms list after being loaded from Splore had a mix of different extensions - some were just called `[game].p8` and others were `[game].p8.png.p8`. I have a tweaked build of MinUI I've been fiddling with that will load the game as its own `.res` boxart if the file is a png (specifically for Pico 8), but it meant neither of these worked.

I think the underlying difference is whether it can extract a "friendly" name from the BBS or uses the raw cart name, but this tweak fixed both cases in my limited testing.

Examples of each case from the (current) "Featured" list are Solitomb and Trichromat.