### PR TITLE
Change governer to set_speed as changing governer

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -88,7 +88,7 @@ launch_cart() {
     cp -f "$PAK_DIR/controllers/$(get_controller_file)" "$HOME/sdl_controllers.txt"
     cp -f "$PAK_DIR/config/$PLATFORM.txt" "$HOME/config.txt"
 
-    echo performance >/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+    echo 1600000 >/sys/devices/system/cpu/cpu0/cpufreq/scaling_setspeed
 
     pico_bin="$(get_pico_bin)"
 


### PR DESCRIPTION
With governer set to performance mode you will loose all control over CPU speed, unless you set it back to manual or something again. Changed it to setspeed instead, did around 1600mhz which should be plenty for Pico8 but probably could even be less. 