### PR TITLE
fix: correct button mapping for tg5040

### DIFF
--- a/controllers/tg5040.txt
+++ b/controllers/tg5040.txt
@@ -1,2 +1,2 @@
 // add SDL2 game controller mappings to this file
-030003f05e0400008e02000014010000,X360 Controller,a:b1,b:b0,back:b6,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b8,leftshoulder:b4,leftstick:b9,lefttrigger:a2,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b10,righttrigger:a5,rightx:a3,righty:a4,start:b8,x:b3,y:b2,platform:Linux
+030003f05e0400008e02000014010000,X360 Controller,a:b0,b:b1,back:b6,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b8,leftshoulder:b4,leftstick:b9,lefttrigger:a2,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b10,righttrigger:a5,rightx:a3,righty:a4,start:b8,x:b3,y:b2,platform:Linux


### PR DESCRIPTION
Swapped the A and B buttons for tg5040 so they correctly match the A and B buttons on the device (i.e. Nintendo layout)