### PR TITLE
Update Shutdown Process

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,8 @@ The following filetypes are supported:
 
 To exit a game:
 
-- press the `Start` button
-- select `Options`
-- select `shutdown Pico-8`
+- Press the `Start` button
+- Select `shutdown`
 
 ### Deep Sleep & Shutdown
 


### PR DESCRIPTION
I'm assuming this is the same on all devices, but on my TrimUI Brick running NextUI the process for shutting down PICO-8 is pressing start and then selecting shutdown.