### PR TITLE
feat: create the splore cart if it does not exist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,5 +4,4 @@
 .gitarchiveinclude export-ignore
 .gitignore export-ignore
 Makefile export-ignore
-Splore.p8 export-ignore
 /test export-ignore

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,3 +102,10 @@ jobs:
             echo "Artifact does not exist"
             exit 1
           fi
+
+      - name: Validate Splore cart is bundled
+        run: |
+          if ! unzip -l "dist/${{ steps.pak-name.outputs.PAK_NAME }}.pak.zip" | grep -q "splore/Splore.p8.png"; then
+            echo "Splore cart is missing from the artifact"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -49,9 +49,11 @@ cee03b8ffd89bd3881a04ab51a21b0f47655c70d20bcec44cd7203274b24a817  pico8
 ### Downloading Roms
 
 1. Create a folder at `/Roms/Pico-8 (PICO)` on your SD card.
-2. Create an empty file named `Splore.p8` in `/Roms/Pico-8 (PICO)` for Splore support.
-3. Place your roms in this directory.
+2. Place your roms in this directory.
     1. See [this itch.io link](https://itch.io/games/downloadable/free/tag-pico-8) for free downloadable Pico-8 games.
+
+> [!NOTE]
+> A `Splore.p8` cart is created for you the first time you launch a game. See [Splore](#splore) for details.
 
 ### Finishing up
 
@@ -89,13 +91,20 @@ Any game that creates in-game saves will save these to `/.userdata/shared/Pico-8
 > [!NOTE]
 > Splore requires an internet connection. The [Wifi.pak](https://github.com/josegonzalez/minui-wifi-pak/) can be used to connect to your network to provide Splore with an internet connection.
 
-To run Splore, create a `Splore.p8` file in `/Roms/Pico-8 (PICO)`. This can be an empty file _or_ it can be one of the two png files in the `splore` directory of this repository. Choosing this game in MinUI will launch the Splore UI. If no WiFi connection is available, Splore will fail to start.
+The first time you launch any game, the pak creates a `Splore.p8` cart, along with matching artwork at `.media/Splore.png`, in every roms folder tagged `(PICO)` on your SD card. Choosing this game in MinUI will launch the Splore UI. If no WiFi connection is available, Splore will fail to start.
+
+The cart is created once and only once. The pak records this by writing a file named `splore-installed` in the `/.userdata/$PLATFORM/Pico-8-native` folder on your SD card, so deleting the cart will not bring it back. To have it recreated, delete `splore-installed` and launch a game again.
+
+A roms folder that already contains a cart with `Splore` or `splore` in its name is left alone.
+
+> [!NOTE]
+> The cart is created while a game is starting, so it will not appear until you leave the folder and enter it again.
 
 Carts downloaded via Splore will only be available via Splore. To copy them to the `/Roms/Pico-8 (PICO)` folder of your SD card, create a file named `copy-carts` in `/.userdata/$PLATFORM/Pico-8-native` folder on your SD card.
 
 To exit Splore, choose a game and follow the normal process of exiting a game.
 
-A sample `Splore.p8` file is included in the base of this repository. You may wish to name the file `1) Splore.p8` to move it to the top of the game list.
+You may wish to rename the cart to `1) Splore.p8` to move it to the top of the game list. Renaming it will not cause a new one to be created. Rename the artwork to match if you do, so `.media/1) Splore.png`. The `splore` folder of this pak also contains `Splore-fancy.p8.png`, an alternative cover you can copy over the generated artwork.
 
 ### Artwork
 

--- a/README.md
+++ b/README.md
@@ -108,39 +108,26 @@ You may wish to rename the cart to `1) Splore.p8` to move it to the top of the g
 
 ### Artwork
 
-MinUI and NextUI both support artwork. P8 files are regular PNG files with the `p8` extension. To display artwork, copy the `p8` files and rename them to `png` and place them in the appropriate folder for your CFW.
+MinUI and NextUI both support artwork, but they look in different folders and name the image differently:
 
-For example, if you have the following file:
+- NextUI reads from a `.media` folder, and the image drops the cart's last extension.
+- MinUI reads from a `.res` folder, and the image keeps the cart's full name.
 
-```shell
-/Roms/Pico-8 (PICO)/Freecell.p8
-```
+PICO-8 carts are PNG images whatever they are named, so the artwork is a copy of the cart itself. Carts ending in `.p8.png` can be copied across as they are. Carts ending in `.p8` need to be renamed to end in `png`.
 
-Copy it over to the correct folder for each CFW.
+For a cart at `/Roms/Pico-8 (PICO)/Freecell.p8`:
 
-For NextUI:
+| CFW | Path |
+| --- | --- |
+| NextUI | `Roms/Pico-8 (PICO)/.media/Freecell.png` |
+| MinUI | `Roms/Pico-8 (PICO)/.res/Freecell.p8.png` |
 
-- Folder: `.media`
-- Path: `Roms/Pico-8 (PICO)/.media/Freecell.png` (omit the `p8` extension)
+For a cart at `/Roms/Pico-8 (PICO)/Freecell.p8.png`:
 
-- Folder: `.res`
-- Path: `Roms/Pico-8 (PICO)/.res/Freecell.p8.png` (include the `p8` extension)
-
-If your PICO-8 files end in `.p8.png`, then you can copy the files over to the respective image folder as is. For example, if you have the following file:
-
-```shell
-/Roms/Pico-8 (PICO)/Freecell.p8.png
-```
-
-Copy it over to the correct folder for each CFW.
-
-For NextUI:
-
-- Folder: `.media`
-- Path: `Roms/Pico-8 (PICO)/.media/Freecell.p8.png` (omit the `p8` extension)
-
-- Folder: `.res`
-- Path: `Roms/Pico-8 (PICO)/.res/Freecell.p8.png` (include the `p8` extension)
+| CFW | Path |
+| --- | --- |
+| NextUI | `Roms/Pico-8 (PICO)/.media/Freecell.p8.png` |
+| MinUI | `Roms/Pico-8 (PICO)/.res/Freecell.p8.png.png` |
 
 ### Multi-cart Game Support
 
@@ -202,7 +189,7 @@ As an example, [Poom](https://freds72.itch.io/poom) - a Doom clone written for P
 
 By default, PICO-8 is launched in as a centered square resolution. For some games, it may be desirable to have the screen drawn such that it stretches to cover the entire screen instead of being 1x1 width to height, in a "stretched" mode that simulates widescreen functionality.
 
-To set the screen mode to `stretched`, create a file named `screen-mode` in `/.userdata/$PLATFORM/Pico-8-native` folder on your SD card. The contents of this can be either of the following:
+The screen mode is held in a file named `screen-mode` in the `/.userdata/$PLATFORM/Pico-8-native` folder on your SD card. The pak creates it set to `standard` the first time you launch a game, and you can edit it yourself. The contents can be either of the following:
 
 - `standard`: the standard screen display, showing the game centered as a square.
 - `stretched`: display the screen stretched to match the width of the device's screen.

--- a/launch.sh
+++ b/launch.sh
@@ -82,9 +82,14 @@ copy_carts() {
 		}'
   }
 
-  grep -v '^$' "$FAV_FILE" | while IFS='|' read -r _ filename_raw _ _ _ _ full_title; do
+  # read from the file rather than a pipe so the loop does not run in a subshell
+  while IFS='|' read -r _ filename_raw _ _ _ _ full_title; do
     filename_raw="${filename_raw#"${filename_raw%%[![:space:]]*}"}"
     filename_raw="${filename_raw%"${filename_raw##*[![:space:]]}"}"
+
+    if [ -z "$filename_raw" ]; then
+      continue
+    fi
 
     full_title="${full_title#"${full_title%%[![:space:]]*}"}"
     full_title="${full_title%"${full_title##*[![:space:]]}"}"
@@ -102,14 +107,14 @@ copy_carts() {
       [ ! -f "$MEDIA_FOLDER/$filename_png" ] && cp -f "$CART_PATH" "$MEDIA_FOLDER/$filename_png"
       printf "%s\t%s\n" "$filename_png" "$full_title" >>"$MAP_FILE"
     fi
-  done
+  done <"$FAV_FILE"
 
   sync
 }
 
 get_screen_mode() {
   if [ ! -f "$USERDATA_PATH/Pico-8-native/screen-mode" ]; then
-    echo "normal" >"$USERDATA_PATH/Pico-8-native/screen-mode"
+    echo "standard" >"$USERDATA_PATH/Pico-8-native/screen-mode"
   fi
 
   cat "$USERDATA_PATH/Pico-8-native/screen-mode"

--- a/launch.sh
+++ b/launch.sh
@@ -151,6 +151,61 @@ is_splore_cart() {
   return 1
 }
 
+rom_folder_has_splore_cart() {
+  splore_folder="$1"
+
+  for splore_entry in "$splore_folder"/*; do
+    [ -f "$splore_entry" ] || continue
+    if is_splore_cart "${splore_entry##*/}"; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+install_splore_cart() {
+  marker_file="$USERDATA_PATH/Pico-8-native/splore-installed"
+  if [ -f "$marker_file" ]; then
+    return 0
+  fi
+
+  source_cart="$PAK_DIR/splore/Splore.p8.png"
+  if [ ! -f "$source_cart" ]; then
+    echo "Splore cart $source_cart is missing, skipping" 1>&2
+    return 0
+  fi
+
+  seeded=false
+  for rom_folder in "$SDCARD_PATH/Roms/"*"($PAK_NAME)"; do
+    [ -d "$rom_folder" ] || continue
+
+    if rom_folder_has_splore_cart "$rom_folder"; then
+      seeded=true
+      continue
+    fi
+
+    echo "Creating Splore.p8 in $rom_folder" 1>&2
+    if ! cp -f "$source_cart" "$rom_folder/Splore.p8"; then
+      echo "Unable to create Splore.p8 in $rom_folder" 1>&2
+      continue
+    fi
+
+    seeded=true
+    mkdir -p "$rom_folder/.media"
+    if [ ! -f "$rom_folder/.media/Splore.png" ]; then
+      cp -f "$source_cart" "$rom_folder/.media/Splore.png"
+    fi
+  done
+
+  if [ "$seeded" = "true" ]; then
+    true >"$marker_file"
+    sync
+  fi
+
+  return 0
+}
+
 launch_cart() {
   ROM_PATH="$1"
   cp -f "$PAK_DIR/controllers/$(get_controller_file)" "$HOME/sdl_controllers.txt"
@@ -324,6 +379,9 @@ main() {
   if ! verify_platform; then
     return 1
   fi
+
+  # seeding is best-effort and must never block a launch
+  install_splore_cart
 
   if ! verify_cart "$ROM_PATH"; then
     return 1

--- a/test/launch.bats
+++ b/test/launch.bats
@@ -317,3 +317,98 @@ setup() {
   [ -f "$USERDATA_PATH/Pico-8-native/splore-installed" ]
   grep -q "is not a supported filetype" "$LOGS_PATH/PICO.txt"
 }
+
+@test "get_screen_mode defaults to the documented standard mode" {
+  run get_screen_mode
+  [ "$status" -eq 0 ]
+  [ "$output" = "standard" ]
+  [ "$(cat "$USERDATA_PATH/Pico-8-native/screen-mode")" = "standard" ]
+}
+
+@test "get_screen_mode keeps a mode the user already chose" {
+  echo "stretched" >"$USERDATA_PATH/Pico-8-native/screen-mode"
+
+  run get_screen_mode
+  [ "$output" = "stretched" ]
+}
+
+@test "copy_carts does nothing without the copy-carts flag" {
+  rom_folder="$(make_rom_folder "Pico-8 (PICO)")"
+  mkdir -p "$HOME/bbs/carts"
+  : >"$HOME/bbs/carts/freecell.p8.png"
+  printf 'x|freecell|x|x|x|x|freecell classic\n' >"$HOME/favourites.txt"
+
+  run copy_carts "$rom_folder"
+  [ "$status" -eq 0 ]
+  [ ! -f "$rom_folder/freecell.p8.png" ]
+  [ ! -f "$rom_folder/map.txt" ]
+}
+
+@test "copy_carts copies a favourited cart and titles it" {
+  : >"$USERDATA_PATH/Pico-8-native/copy-carts"
+  rom_folder="$(make_rom_folder "Pico-8 (PICO)")"
+  mkdir -p "$HOME/bbs/carts"
+  : >"$HOME/bbs/carts/freecell.p8.png"
+  printf 'x|freecell|x|x|x|x|freecell classic\n' >"$HOME/favourites.txt"
+
+  run copy_carts "$rom_folder"
+  [ "$status" -eq 0 ]
+
+  [ -f "$rom_folder/freecell.p8.png" ]
+  [ -f "$rom_folder/.media/freecell.p8.png" ]
+  grep -q "^freecell.p8.png	Freecell Classic$" "$rom_folder/map.txt"
+}
+
+@test "copy_carts resolves a numerically named cart to its bbs subfolder" {
+  : >"$USERDATA_PATH/Pico-8-native/copy-carts"
+  rom_folder="$(make_rom_folder "Pico-8 (PICO)")"
+  mkdir -p "$HOME/bbs/4"
+  : >"$HOME/bbs/4/42000.p8.png"
+  printf 'x|42000|x|x|x|x|the answer\n' >"$HOME/favourites.txt"
+
+  run copy_carts "$rom_folder"
+  [ "$status" -eq 0 ]
+
+  [ -f "$rom_folder/42000.p8.png" ]
+  grep -q "^42000.p8.png	The Answer$" "$rom_folder/map.txt"
+}
+
+@test "copy_carts skips blank lines in the favourites file" {
+  : >"$USERDATA_PATH/Pico-8-native/copy-carts"
+  rom_folder="$(make_rom_folder "Pico-8 (PICO)")"
+  mkdir -p "$HOME/bbs/carts"
+  : >"$HOME/bbs/carts/freecell.p8.png"
+  printf '\nx|freecell|x|x|x|x|freecell classic\n\n' >"$HOME/favourites.txt"
+
+  run copy_carts "$rom_folder"
+  [ "$status" -eq 0 ]
+
+  [ -f "$rom_folder/freecell.p8.png" ]
+  [ "$(wc -l <"$rom_folder/map.txt")" -eq 1 ]
+}
+
+@test "copy_carts ignores a favourite with no downloaded cart" {
+  : >"$USERDATA_PATH/Pico-8-native/copy-carts"
+  rom_folder="$(make_rom_folder "Pico-8 (PICO)")"
+  mkdir -p "$HOME/bbs/carts"
+  printf 'x|missing|x|x|x|x|missing cart\n' >"$HOME/favourites.txt"
+
+  run copy_carts "$rom_folder"
+  [ "$status" -eq 0 ]
+
+  [ ! -f "$rom_folder/missing.p8.png" ]
+  [ ! -s "$rom_folder/map.txt" ]
+}
+
+@test "copy_carts runs its loop in the current shell" {
+  : >"$USERDATA_PATH/Pico-8-native/copy-carts"
+  rom_folder="$(make_rom_folder "Pico-8 (PICO)")"
+  mkdir -p "$HOME/bbs/carts"
+  : >"$HOME/bbs/carts/freecell.p8.png"
+  printf 'x|freecell|x|x|x|x|freecell classic\n' >"$HOME/favourites.txt"
+
+  filename_png=""
+  copy_carts "$rom_folder"
+
+  [ "$filename_png" = "freecell.p8.png" ]
+}

--- a/test/launch.bats
+++ b/test/launch.bats
@@ -102,6 +102,142 @@ setup() {
   [ "$status" -eq 1 ]
 }
 
+@test "rom_folder_has_splore_cart finds an existing splore cart" {
+  rom_folder="$(make_rom_folder "Pico-8 (PICO)")"
+  : >"$rom_folder/1) Splore.p8.png"
+
+  run rom_folder_has_splore_cart "$rom_folder"
+  [ "$status" -eq 0 ]
+}
+
+@test "rom_folder_has_splore_cart ignores ordinary carts" {
+  rom_folder="$(make_rom_folder "Pico-8 (PICO)")"
+  : >"$rom_folder/Freecell.p8"
+
+  run rom_folder_has_splore_cart "$rom_folder"
+  [ "$status" -eq 1 ]
+}
+
+@test "rom_folder_has_splore_cart ignores an empty folder" {
+  rom_folder="$(make_rom_folder "Pico-8 (PICO)")"
+
+  run rom_folder_has_splore_cart "$rom_folder"
+  [ "$status" -eq 1 ]
+}
+
+@test "rom_folder_has_splore_cart ignores a directory named splore" {
+  rom_folder="$(make_rom_folder "Pico-8 (PICO)")"
+  mkdir -p "$rom_folder/Splore"
+
+  run rom_folder_has_splore_cart "$rom_folder"
+  [ "$status" -eq 1 ]
+}
+
+@test "rom_folder_has_splore_cart matches the file name not the folder path" {
+  rom_folder="$(make_rom_folder "Splore Carts (PICO)")"
+  : >"$rom_folder/Freecell.p8"
+
+  run rom_folder_has_splore_cart "$rom_folder"
+  [ "$status" -eq 1 ]
+}
+
+@test "install_splore_cart seeds a tagged roms folder" {
+  rom_folder="$(make_rom_folder "Pico-8 (PICO)")"
+
+  run install_splore_cart
+  [ "$status" -eq 0 ]
+
+  [ -f "$rom_folder/Splore.p8" ]
+  [ -f "$rom_folder/.media/Splore.png" ]
+  [ -f "$USERDATA_PATH/Pico-8-native/splore-installed" ]
+  cmp -s "$REPO_ROOT/splore/Splore.p8.png" "$rom_folder/Splore.p8"
+  cmp -s "$REPO_ROOT/splore/Splore.p8.png" "$rom_folder/.media/Splore.png"
+}
+
+@test "install_splore_cart seeds every tagged roms folder" {
+  first="$(make_rom_folder "Pico-8 (PICO)")"
+  second="$(make_rom_folder "Extra Pico (PICO)")"
+
+  run install_splore_cart
+  [ "$status" -eq 0 ]
+
+  [ -f "$first/Splore.p8" ]
+  [ -f "$second/Splore.p8" ]
+  [ -f "$USERDATA_PATH/Pico-8-native/splore-installed" ]
+}
+
+@test "install_splore_cart skips a folder that already has a splore cart" {
+  rom_folder="$(make_rom_folder "Pico-8 (PICO)")"
+  : >"$rom_folder/1) Splore.p8.png"
+
+  run install_splore_cart
+  [ "$status" -eq 0 ]
+
+  [ ! -f "$rom_folder/Splore.p8" ]
+  [ ! -d "$rom_folder/.media" ]
+  [ -f "$USERDATA_PATH/Pico-8-native/splore-installed" ]
+}
+
+@test "install_splore_cart does not recreate a cart the user deleted" {
+  rom_folder="$(make_rom_folder "Pico-8 (PICO)")"
+  : >"$USERDATA_PATH/Pico-8-native/splore-installed"
+
+  run install_splore_cart
+  [ "$status" -eq 0 ]
+
+  [ ! -f "$rom_folder/Splore.p8" ]
+  [ ! -d "$rom_folder/.media" ]
+}
+
+@test "install_splore_cart does not write the marker without a tagged roms folder" {
+  run install_splore_cart
+  [ "$status" -eq 0 ]
+  [ ! -f "$USERDATA_PATH/Pico-8-native/splore-installed" ]
+}
+
+@test "install_splore_cart ignores folders for other emulators" {
+  rom_folder="$(make_rom_folder "Game Boy (GB)")"
+
+  run install_splore_cart
+  [ "$status" -eq 0 ]
+
+  [ ! -f "$rom_folder/Splore.p8" ]
+  [ ! -f "$USERDATA_PATH/Pico-8-native/splore-installed" ]
+}
+
+@test "install_splore_cart ignores a tagged path that is not a directory" {
+  : >"$SDCARD_PATH/Roms/Pico-8 (PICO)"
+
+  run install_splore_cart
+  [ "$status" -eq 0 ]
+  [ ! -f "$USERDATA_PATH/Pico-8-native/splore-installed" ]
+}
+
+@test "install_splore_cart tolerates a missing source cart" {
+  make_rom_folder "Pico-8 (PICO)" >/dev/null
+
+  PAK_DIR="$BATS_TEST_TMPDIR/no-pak" run install_splore_cart
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"is missing, skipping"* ]]
+  [ ! -f "$USERDATA_PATH/Pico-8-native/splore-installed" ]
+}
+
+@test "install_splore_cart does not mark a folder it could not write to" {
+  if [ "$(id -u)" -eq 0 ]; then
+    skip "chmod does not restrict root"
+  fi
+
+  rom_folder="$(make_rom_folder "Pico-8 (PICO)")"
+  chmod 555 "$rom_folder"
+
+  run install_splore_cart
+  chmod 755 "$rom_folder"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Unable to create"* ]]
+  [ ! -f "$USERDATA_PATH/Pico-8-native/splore-installed" ]
+}
+
 @test "get_pico_bin returns the dynamic binary on rg35xxplus" {
   PLATFORM=rg35xxplus run get_pico_bin
   [ "$output" = "pico8_dyn" ]
@@ -158,4 +294,26 @@ setup() {
 
   [ "$status" -eq 1 ]
   grep -q "does not exist" "$LOGS_PATH/PICO.txt"
+}
+
+@test "launch.sh seeds the splore cart even when the cart is invalid" {
+  pak_dir="$BATS_TEST_TMPDIR/PICO.pak"
+  mkdir -p "$pak_dir"
+  ln -s "$REPO_ROOT/launch.sh" "$pak_dir/launch.sh"
+  ln -s "$REPO_ROOT/splore" "$pak_dir/splore"
+
+  rom_folder="$(make_rom_folder "Pico-8 (PICO)")"
+  cart="$(make_cart Game.txt)"
+
+  run env PATH="$STUB_BIN:$PATH" PLATFORM=tg5050 DEVICE= \
+    PICO_PAK_SOURCE_ONLY= \
+    SDCARD_PATH="$SDCARD_PATH" USERDATA_PATH="$USERDATA_PATH" \
+    SHARED_USERDATA_PATH="$SHARED_USERDATA_PATH" LOGS_PATH="$LOGS_PATH" \
+    sh "$pak_dir/launch.sh" "$cart"
+
+  [ "$status" -eq 1 ]
+  [ -f "$rom_folder/Splore.p8" ]
+  [ -f "$rom_folder/.media/Splore.png" ]
+  [ -f "$USERDATA_PATH/Pico-8-native/splore-installed" ]
+  grep -q "is not a supported filetype" "$LOGS_PATH/PICO.txt"
 }

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -22,6 +22,7 @@ setup_launch() {
   export SHARED_USERDATA_PATH="$BATS_TEST_TMPDIR/shared"
   export LOGS_PATH="$BATS_TEST_TMPDIR/logs"
   mkdir -p "$SDCARD_PATH" "$USERDATA_PATH" "$SHARED_USERDATA_PATH" "$LOGS_PATH"
+  mkdir -p "$SDCARD_PATH/Roms" "$USERDATA_PATH/Pico-8-native" "$SHARED_USERDATA_PATH/Pico-8-native"
 
   CARTS="$BATS_TEST_TMPDIR/carts"
   export CARTS
@@ -31,6 +32,13 @@ setup_launch() {
   # shellcheck source=/dev/null
   . "$REPO_ROOT/launch.sh"
 
+  # launch.sh derives these from "$0", which is the bats runner when the file is
+  # sourced rather than executed. Point them back at the repo so the functions
+  # under test resolve real pak files.
+  PAK_DIR="$REPO_ROOT"
+  PAK_NAME="PICO"
+  export PAK_DIR PAK_NAME
+
   PATH="$STUB_BIN:$PATH"
   export PATH
 }
@@ -39,5 +47,12 @@ setup_launch() {
 make_cart() {
   local path="$CARTS/$1"
   : >"$path"
+  printf '%s' "$path"
+}
+
+# Creates a roms folder under the fake SD card and echoes its path.
+make_rom_folder() {
+  local path="$SDCARD_PATH/Roms/$1"
+  mkdir -p "$path"
   printf '%s' "$path"
 }


### PR DESCRIPTION
Reaching Splore required hand-creating a file in the roms folder, and nothing in the pak said so apart from one line of the readme, so anyone who missed that step had no way in and no hint that they were missing anything. The pak now seeds a `Splore.p8` cart, and matching artwork, into every roms folder tagged for it on the first launch. The cart image already shipped inside the pak but was never copied out.

Seeding happens once and is recorded in userdata, so deleting the cart is respected. A folder that already holds a splore cart is left alone, and that check reuses the same helper the launcher dispatches on, so the two cannot disagree. A folder that cannot be written to is not recorded, leaving the next launch free to retry rather than losing the cart permanently.

The roms folders are found by tag rather than from the launched cart, since a multi-cart game hands the pak a subfolder. Seeding runs before the cart is validated so that an unsupported file, which is exactly what a new user is likely to pick, does not prevent it, and it can never fail a launch.

The release workflow now checks that the cart image is actually bundled, because losing it would turn the whole feature into a silent no-op. A stale export rule for a file removed in `84b9b58` is dropped.

Three unrelated problems that predate this branch are fixed alongside it. The screen mode file was created holding a value the readme never mentions, so the documented default and the real one disagreed; the default is now the documented one. The cart copier read its favourites through a pipe, putting the loop in a subshell that discarded anything it set, which is inert today but a trap for any later change; it now reads from the file directly, and its previously untested behaviour is pinned first. The artwork section labelled both image folders as NextUI when `.res` belongs to MinUI, and gave a path for `.p8.png` carts that ignored the naming rule it had just stated for `.p8` carts.

Closes #25
