### PR TITLE
feat: prompt before launching splore without a connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,16 @@ Any game that creates in-game saves will save these to `/.userdata/shared/Pico-8
 ### Splore
 
 > [!NOTE]
-> Splore requires an internet connection. The [Wifi.pak](https://github.com/josegonzalez/minui-wifi-pak/) can be used to connect to your network to provide Splore with an internet connection.
+> Splore requires an internet connection to browse and download new carts. The [Wifi.pak](https://github.com/josegonzalez/minui-wifi-pak/) can be used to connect to your network to provide Splore with an internet connection.
 
-The first time you launch any game, the pak creates a `Splore.p8` cart, along with matching artwork at `.media/Splore.png`, in every roms folder tagged `(PICO)` on your SD card. Choosing this game in MinUI will launch the Splore UI. If no WiFi connection is available, Splore will fail to start.
+The first time you launch any game, the pak creates a `Splore.p8` cart, along with matching artwork at `.media/Splore.png`, in every roms folder tagged `(PICO)` on your SD card. Choosing this game in MinUI will launch the Splore UI.
+
+Before Splore starts, the pak checks that the device has a network connection and then downloads a small file from `lexaloffle.com` to confirm the Splore servers are reachable. If either check fails, a message is displayed and waits for you to choose:
+
+- `CONTINUE` starts Splore anyway. Carts you have already downloaded stay browsable, but new carts cannot be fetched.
+- `EXIT` returns to MinUI without starting Splore.
+
+This check only runs for the Splore cart. Ordinary carts start without touching the network.
 
 The cart is created once and only once. The pak records this by writing a file named `splore-installed` in the `/.userdata/$PLATFORM/Pico-8-native` folder on your SD card, so deleting the cart will not bring it back. To have it recreated, delete `splore-installed` and launch a game again.
 
@@ -213,3 +220,5 @@ make lint
 make format
 make test
 ```
+
+Two environment variables exist for the test suite only. `PICO_PAK_SOURCE_ONLY` sources `launch.sh` without running `main`, and `PICO_PAK_NET_DIR` overrides the `/sys/class/net` directory the network check reads.

--- a/launch.sh
+++ b/launch.sh
@@ -146,6 +146,53 @@ get_controller_file() {
   fi
 }
 
+get_network_probe_file() {
+  echo "/tmp/$PAK_NAME-network-probe"
+}
+
+# the sysfs directory is overridable so the test suite can fake a link state
+is_network_link_up() {
+  net_dir="${PICO_PAK_NET_DIR:-/sys/class/net}"
+
+  for interface_dir in "$net_dir"/*; do
+    [ -d "$interface_dir" ] || continue
+
+    interface="${interface_dir##*/}"
+    if [ "$interface" = "lo" ]; then
+      continue
+    fi
+
+    if [ "$(cat "$interface_dir/operstate" 2>/dev/null)" = "up" ]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+is_internet_reachable() {
+  probe_url="https://www.lexaloffle.com/robots.txt"
+  probe_file="$(get_network_probe_file)"
+  rm -f "$probe_file"
+
+  # every platform ships its own wget shim, and two of them are curl wrappers
+  # that read only the url and the output path, so no timeout flag survives
+  if command -v timeout >/dev/null 2>&1; then
+    timeout 10s wget "$probe_url" -q -O "$probe_file" || true
+  else
+    wget "$probe_url" -q -O "$probe_file" || true
+  fi
+
+  # a failed fetch leaves an empty file behind on every platform
+  if [ -s "$probe_file" ]; then
+    rm -f "$probe_file"
+    return 0
+  fi
+
+  rm -f "$probe_file"
+  return 1
+}
+
 is_splore_cart() {
   case "$1" in
   *"Splore"* | *"splore"*)
@@ -238,12 +285,6 @@ launch_cart() {
   fi
 
   if is_splore_cart "$ROM_NAME"; then
-    enabled="$(cat /sys/class/net/wlan0/operstate 2>/dev/null)"
-    if [ "$enabled" != "up" ]; then
-      show_message "Required wifi connection is not available." 2
-      return 1
-    fi
-
     # draw_rect is left unquoted so it splits into separate arguments
     # shellcheck disable=SC2086
     "$pico_bin" \
@@ -316,6 +357,38 @@ verify_cart() {
   return 1
 }
 
+verify_splore_connection() {
+  splore_cart_name="$(basename "$1")"
+
+  if ! is_splore_cart "$splore_cart_name"; then
+    return 0
+  fi
+
+  # show_message and show_confirmation both assign to a variable named message,
+  # and this shell has no locals, so the prompt text needs its own name
+  splore_message=""
+  if ! is_network_link_up; then
+    splore_message="No network connection was detected. Use Wifi.pak to connect. Splore can still browse the carts already downloaded to this device."
+  else
+    show_message "Checking the connection to the Splore servers." forever
+    if ! is_internet_reachable; then
+      splore_message="The Lexaloffle servers could not be reached. Check your connection. Splore can still browse the carts already downloaded to this device."
+    fi
+    killall minui-presenter >/dev/null 2>&1 || true
+  fi
+
+  if [ -z "$splore_message" ]; then
+    return 0
+  fi
+
+  # normalise the presenter's exit code so the gate matches its verify_ siblings
+  if show_confirmation "$splore_message"; then
+    return 0
+  fi
+
+  return 1
+}
+
 install_pico_files() {
   pico_bin="$(get_pico_bin)"
 
@@ -354,8 +427,25 @@ show_message() {
   fi
 }
 
+show_confirmation() {
+  message="$1"
+  confirm_text="${2:-CONTINUE}"
+  cancel_text="${3:-EXIT}"
+
+  killall minui-presenter >/dev/null 2>&1 || true
+  echo "$message" 1>&2
+  minui-presenter \
+    --cancel-show \
+    --cancel-text "$cancel_text" \
+    --confirm-show \
+    --confirm-text "$confirm_text" \
+    --message "$message" \
+    --timeout 0
+}
+
 cleanup() {
   rm -f /tmp/stay_awake
+  rm -f "$(get_network_probe_file)"
   killall minui-presenter >/dev/null 2>&1 || true
 }
 
@@ -393,6 +483,10 @@ main() {
   fi
 
   if ! install_pico_files; then
+    return 1
+  fi
+
+  if ! verify_splore_connection "$ROM_PATH"; then
     return 1
   fi
 

--- a/test/launch.bats
+++ b/test/launch.bats
@@ -412,3 +412,302 @@ setup() {
 
   [ "$filename_png" = "freecell.p8.png" ]
 }
+
+@test "is_network_link_up detects an interface that is up" {
+  stub_network up
+
+  run is_network_link_up
+  [ "$status" -eq 0 ]
+}
+
+@test "is_network_link_up rejects an interface that is down" {
+  stub_network down
+
+  run is_network_link_up
+  [ "$status" -eq 1 ]
+}
+
+@test "is_network_link_up ignores the loopback interface" {
+  stub_network up lo
+
+  run is_network_link_up
+  [ "$status" -eq 1 ]
+}
+
+@test "is_network_link_up accepts a tethered interface" {
+  stub_network up eth0
+
+  run is_network_link_up
+  [ "$status" -eq 0 ]
+}
+
+@test "is_network_link_up accepts any interface that is up" {
+  stub_network up lo
+  stub_network down wlan0
+  stub_network up eth0
+
+  run is_network_link_up
+  [ "$status" -eq 0 ]
+}
+
+@test "is_network_link_up ignores an interface with no operstate file" {
+  stub_network "" wlan0
+
+  run is_network_link_up
+  [ "$status" -eq 1 ]
+}
+
+@test "is_network_link_up handles a device with no interfaces" {
+  run is_network_link_up
+  [ "$status" -eq 1 ]
+}
+
+@test "is_network_link_up handles a missing sysfs directory" {
+  PICO_PAK_NET_DIR="$BATS_TEST_TMPDIR/absent" run is_network_link_up
+  [ "$status" -eq 1 ]
+  [ -z "$output" ]
+}
+
+@test "get_network_probe_file is namespaced by the pak name" {
+  run get_network_probe_file
+  [ "$output" = "/tmp/PICO-network-probe" ]
+}
+
+@test "is_internet_reachable succeeds when the probe downloads a body" {
+  stub_wget reachable
+
+  run is_internet_reachable
+  [ "$status" -eq 0 ]
+}
+
+@test "is_internet_reachable fails when the probe leaves an empty file" {
+  stub_wget unreachable
+
+  run is_internet_reachable
+  [ "$status" -eq 1 ]
+}
+
+@test "is_internet_reachable fails when the body is empty" {
+  stub_wget empty
+
+  run is_internet_reachable
+  [ "$status" -eq 1 ]
+}
+
+@test "is_internet_reachable fails when the probe writes nothing" {
+  stub_wget silent
+
+  run is_internet_reachable
+  [ "$status" -eq 1 ]
+}
+
+@test "is_internet_reachable requests the lexaloffle probe url" {
+  stub_wget reachable
+
+  is_internet_reachable
+  grep -q "https://www.lexaloffle.com/robots.txt" "$WGET_LOG"
+}
+
+@test "is_internet_reachable obeys the positional shim contract" {
+  stub_wget reachable
+
+  is_internet_reachable
+  grep -q -- "-q -O /tmp/PICO-network-probe" "$WGET_LOG"
+}
+
+@test "is_internet_reachable removes the probe file" {
+  stub_wget reachable
+  is_internet_reachable
+  [ ! -f "$(get_network_probe_file)" ]
+
+  stub_wget unreachable
+  ! is_internet_reachable
+  [ ! -f "$(get_network_probe_file)" ]
+}
+
+@test "is_internet_reachable bounds the probe with timeout" {
+  stub_wget reachable
+  stub_timeout
+
+  run is_internet_reachable
+  [ "$status" -eq 0 ]
+  grep -q "^10s wget https://www.lexaloffle.com/robots.txt" "$TIMEOUT_LOG"
+}
+
+@test "show_confirmation returns zero when the user confirms" {
+  stub_presenter 0
+
+  run show_confirmation "are you sure"
+  [ "$status" -eq 0 ]
+}
+
+@test "show_confirmation returns non-zero when the user cancels" {
+  stub_presenter 2
+
+  run show_confirmation "are you sure"
+  [ "$status" -ne 0 ]
+}
+
+@test "show_confirmation blocks with continue and exit buttons" {
+  stub_presenter 0
+
+  show_confirmation "are you sure"
+  grep -q -- "--confirm-show --confirm-text CONTINUE" "$PRESENTER_CONFIRM_LOG"
+  grep -q -- "--cancel-show --cancel-text EXIT" "$PRESENTER_CONFIRM_LOG"
+  grep -q -- "--timeout 0" "$PRESENTER_CONFIRM_LOG"
+}
+
+@test "show_confirmation uses the button text it is given" {
+  stub_presenter 0
+
+  show_confirmation "are you sure" YES NO
+  grep -q -- "--confirm-text YES" "$PRESENTER_CONFIRM_LOG"
+  grep -q -- "--cancel-text NO" "$PRESENTER_CONFIRM_LOG"
+}
+
+@test "verify_splore_connection ignores an ordinary cart" {
+  stub_presenter 0
+  stub_wget reachable
+
+  run verify_splore_connection "$(make_cart Game.p8)"
+  [ "$status" -eq 0 ]
+  [ ! -f "$WGET_LOG" ]
+  [ ! -f "$PRESENTER_CONFIRM_LOG" ]
+}
+
+@test "verify_splore_connection ignores a cart inside a splore named folder" {
+  stub_presenter 0
+  stub_wget reachable
+
+  run verify_splore_connection "$SDCARD_PATH/Roms/Splore Carts (PICO)/Game.p8"
+  [ "$status" -eq 0 ]
+  [ ! -f "$PRESENTER_CONFIRM_LOG" ]
+}
+
+@test "verify_splore_connection allows splore when the servers respond" {
+  stub_network up
+  stub_presenter 0
+  stub_wget reachable
+
+  run verify_splore_connection "$(make_cart Splore.p8)"
+  [ "$status" -eq 0 ]
+  [ ! -f "$PRESENTER_CONFIRM_LOG" ]
+}
+
+@test "verify_splore_connection warns when there is no network link" {
+  stub_presenter 0
+  stub_wget reachable
+
+  run verify_splore_connection "$(make_cart Splore.p8)"
+  [ "$status" -eq 0 ]
+  grep -q "No network connection was detected" "$PRESENTER_CONFIRM_LOG"
+  [ ! -f "$WGET_LOG" ]
+}
+
+@test "verify_splore_connection aborts when the user exits the link warning" {
+  stub_presenter 2
+  stub_wget reachable
+
+  run verify_splore_connection "$(make_cart Splore.p8)"
+  [ "$status" -eq 1 ]
+}
+
+@test "verify_splore_connection warns when the servers are unreachable" {
+  stub_network up
+  stub_presenter 0
+  stub_wget unreachable
+
+  run verify_splore_connection "$(make_cart Splore.p8)"
+  [ "$status" -eq 0 ]
+  grep -q "Lexaloffle servers could not be reached" "$PRESENTER_CONFIRM_LOG"
+}
+
+@test "verify_splore_connection aborts when the user exits the server warning" {
+  stub_network up
+  stub_presenter 2
+  stub_wget unreachable
+
+  run verify_splore_connection "$(make_cart Splore.p8)"
+  [ "$status" -eq 1 ]
+}
+
+@test "verify_splore_connection matches a renamed splore cart" {
+  stub_presenter 0
+  stub_wget reachable
+
+  run verify_splore_connection "$(make_cart "1) Splore.p8.png")"
+  [ "$status" -eq 0 ]
+  grep -q "No network connection was detected" "$PRESENTER_CONFIRM_LOG"
+}
+
+@test "launch.sh exits non-zero when the user exits the splore warning" {
+  pak_dir="$BATS_TEST_TMPDIR/PICO.pak"
+  mkdir -p "$pak_dir"
+  ln -s "$REPO_ROOT/launch.sh" "$pak_dir/launch.sh"
+  ln -s "$REPO_ROOT/splore" "$pak_dir/splore"
+
+  make_bios
+  stub_presenter 2
+  rom_folder="$(make_rom_folder "Pico-8 (PICO)")"
+  cart="$rom_folder/Splore.p8"
+  : >"$cart"
+
+  run env PATH="$STUB_BIN:$PATH" PLATFORM=tg5050 DEVICE= \
+    PICO_PAK_SOURCE_ONLY= PICO_PAK_NET_DIR="$PICO_PAK_NET_DIR" \
+    SDCARD_PATH="$SDCARD_PATH" USERDATA_PATH="$USERDATA_PATH" \
+    SHARED_USERDATA_PATH="$SHARED_USERDATA_PATH" LOGS_PATH="$LOGS_PATH" \
+    sh "$pak_dir/launch.sh" "$cart"
+
+  [ "$status" -eq 1 ]
+  grep -q "No network connection was detected" "$LOGS_PATH/PICO.txt"
+}
+
+@test "launch.sh does not start power control when the warning is exited" {
+  pak_dir="$BATS_TEST_TMPDIR/PICO.pak"
+  mkdir -p "$pak_dir"
+  ln -s "$REPO_ROOT/launch.sh" "$pak_dir/launch.sh"
+  ln -s "$REPO_ROOT/splore" "$pak_dir/splore"
+
+  make_bios
+  stub_presenter 2
+  rom_folder="$(make_rom_folder "Pico-8 (PICO)")"
+  cart="$rom_folder/Splore.p8"
+  : >"$cart"
+
+  run env PATH="$STUB_BIN:$PATH" PLATFORM=tg5050 DEVICE= \
+    PICO_PAK_SOURCE_ONLY= PICO_PAK_NET_DIR="$PICO_PAK_NET_DIR" \
+    SDCARD_PATH="$SDCARD_PATH" USERDATA_PATH="$USERDATA_PATH" \
+    SHARED_USERDATA_PATH="$SHARED_USERDATA_PATH" LOGS_PATH="$LOGS_PATH" \
+    sh "$pak_dir/launch.sh" "$cart"
+
+  [ "$status" -eq 1 ]
+  ! grep -q "minui-power-control" "$LOGS_PATH/PICO.txt"
+}
+
+@test "launch.sh starts splore when the user continues past the warning" {
+  pak_dir="$BATS_TEST_TMPDIR/PICO.pak"
+  mkdir -p "$pak_dir/pico8"
+  ln -s "$REPO_ROOT/launch.sh" "$pak_dir/launch.sh"
+  ln -s "$REPO_ROOT/splore" "$pak_dir/splore"
+  ln -s "$REPO_ROOT/controllers" "$pak_dir/controllers"
+  ln -s "$REPO_ROOT/config" "$pak_dir/config"
+  printf '#!/bin/sh\nexit 0\n' >"$pak_dir/pico8/pico8_64"
+  chmod +x "$pak_dir/pico8/pico8_64"
+  : >"$pak_dir/pico8/pico8.dat"
+
+  make_bios
+  stub_presenter 0
+  rom_folder="$(make_rom_folder "Pico-8 (PICO)")"
+  cart="$rom_folder/Splore.p8"
+  : >"$cart"
+
+  run env PATH="$STUB_BIN:$PATH" PLATFORM=tg5050 DEVICE= \
+    PICO_PAK_SOURCE_ONLY= PICO_PAK_NET_DIR="$PICO_PAK_NET_DIR" \
+    SDCARD_PATH="$SDCARD_PATH" USERDATA_PATH="$USERDATA_PATH" \
+    SHARED_USERDATA_PATH="$SHARED_USERDATA_PATH" LOGS_PATH="$LOGS_PATH" \
+    sh "$pak_dir/launch.sh" "$cart"
+
+  [ "$status" -eq 0 ]
+  grep -q "No network connection was detected" "$LOGS_PATH/PICO.txt"
+  grep -q -- "-splore" "$LOGS_PATH/PICO.txt"
+}

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -28,6 +28,13 @@ setup_launch() {
   export CARTS
   mkdir -p "$CARTS"
 
+  # An empty tree is the baseline, so the suite never reads the host's real
+  # network state. macOS has no /sys/class/net at all and the CI runner has a
+  # populated one, which would otherwise make the link check non-deterministic.
+  PICO_PAK_NET_DIR="$BATS_TEST_TMPDIR/net"
+  export PICO_PAK_NET_DIR
+  mkdir -p "$PICO_PAK_NET_DIR"
+
   export PICO_PAK_SOURCE_ONLY=1
   # shellcheck source=/dev/null
   . "$REPO_ROOT/launch.sh"
@@ -55,4 +62,110 @@ make_rom_folder() {
   local path="$SDCARD_PATH/Roms/$1"
   mkdir -p "$path"
   printf '%s' "$path"
+}
+
+# Creates a fake sysfs network interface with the given operstate. The interface
+# defaults to wlan0. Call it on top of the empty tree setup_launch builds.
+stub_network() {
+  local state="$1"
+  local interface="${2:-wlan0}"
+
+  mkdir -p "$PICO_PAK_NET_DIR/$interface"
+  if [ -n "$state" ]; then
+    printf '%s\n' "$state" >"$PICO_PAK_NET_DIR/$interface/operstate"
+  fi
+}
+
+# Replaces the minui-presenter stub with one that logs its arguments and exits
+# with the given code, where 0 confirms a dialog and non-zero cancels it.
+#
+# show_message backgrounds the presenter, so logging every call to one file
+# races with assertions made after the function under test returns. Only the
+# blocking dialog passes --confirm-show, and that call runs in the foreground,
+# so it is logged separately and can be asserted on deterministically.
+#
+# Arguments are logged as "$*" on a single line so that flag and value
+# adjacency can be asserted, for example "--confirm-text CONTINUE".
+stub_presenter() {
+  PRESENTER_LOG="$BATS_TEST_TMPDIR/presenter.log"
+  PRESENTER_CONFIRM_LOG="$BATS_TEST_TMPDIR/presenter.confirm.log"
+  PRESENTER_EXIT="$BATS_TEST_TMPDIR/presenter.exit"
+  export PRESENTER_LOG PRESENTER_CONFIRM_LOG PRESENTER_EXIT
+  printf '%s' "${1:-0}" >"$PRESENTER_EXIT"
+
+  cat >"$STUB_BIN/minui-presenter" <<'STUB'
+#!/bin/sh
+for arg in "$@"; do
+  if [ "$arg" = "--confirm-show" ]; then
+    printf '%s\n' "$*" >>"$PRESENTER_CONFIRM_LOG"
+    exit "$(cat "$PRESENTER_EXIT")"
+  fi
+done
+printf '%s\n' "$*" >>"$PRESENTER_LOG"
+exit 0
+STUB
+  chmod +x "$STUB_BIN/minui-presenter"
+}
+
+# Replaces the wget stub with one that logs its arguments and reproduces one of
+# the outcomes the platform shims produce:
+#
+#   reachable    a body is written and the fetch succeeds
+#   unreachable  an empty file is left behind and the fetch fails
+#   empty        an empty file is left behind but the fetch reports success
+#   silent       nothing is written at all and the fetch reports success
+#
+# The output path is read from $4 to match the positional contract of the curl
+# based shims on rg35xxplus and tg5050.
+stub_wget() {
+  WGET_LOG="$BATS_TEST_TMPDIR/wget.log"
+  WGET_MODE="$BATS_TEST_TMPDIR/wget.mode"
+  export WGET_LOG WGET_MODE
+  printf '%s' "${1:-reachable}" >"$WGET_MODE"
+
+  cat >"$STUB_BIN/wget" <<'STUB'
+#!/bin/sh
+printf '%s\n' "$*" >>"$WGET_LOG"
+mode="$(cat "$WGET_MODE")"
+if [ "$mode" = "reachable" ]; then
+  printf 'User-agent: *\n' >"$4"
+  exit 0
+fi
+if [ "$mode" = "empty" ]; then
+  : >"$4"
+  exit 0
+fi
+if [ "$mode" = "silent" ]; then
+  exit 0
+fi
+: >"$4"
+exit 1
+STUB
+  chmod +x "$STUB_BIN/wget"
+}
+
+# Puts a recording timeout on PATH so the bounded probe can be asserted on hosts
+# that do not ship one. Opt in per test and never remove it mid-test: dropping a
+# command from PATH leaves a stale entry in the shell's command hash table, so
+# `command -v` keeps succeeding while the exec fails.
+stub_timeout() {
+  TIMEOUT_LOG="$BATS_TEST_TMPDIR/timeout.log"
+  export TIMEOUT_LOG
+
+  cat >"$STUB_BIN/timeout" <<'STUB'
+#!/bin/sh
+printf '%s\n' "$*" >>"$TIMEOUT_LOG"
+shift
+exec "$@"
+STUB
+  chmod +x "$STUB_BIN/timeout"
+}
+
+# Creates the files install_pico_files requires, so end to end tests reach the
+# checks that run after it.
+make_bios() {
+  mkdir -p "$SDCARD_PATH/Bios/PICO"
+  for bios in pico8 pico8_64 pico8_dyn pico8.dat; do
+    : >"$SDCARD_PATH/Bios/PICO/$bios"
+  done
 }


### PR DESCRIPTION
Splore previously flashed a two second message and exited when `wlan0` was not up. The message was easy to miss, link state said nothing about whether the Lexaloffle servers were actually reachable, and there was no way to continue even though Splore can still browse carts that have already been downloaded.

The pak now checks for any non-loopback interface that is up, then downloads a small file from lexaloffle.com to confirm the servers respond. Either failure shows a blocking prompt offering to continue or to exit. The check moved out of `launch_cart` into `main` so that declining no longer orphans the backgrounded power control process.

Closes #32